### PR TITLE
fix: update rb_cData to rb_cObject to support Ruby 3.2+

### DIFF
--- a/ext/cppjieba_rb/internal.cc
+++ b/ext/cppjieba_rb/internal.cc
@@ -163,7 +163,7 @@ void Init_internal()
     rb_sFull = rb_intern("full");
     u8_enc = rb_utf8_encoding();
 
-    rb_cCppjiebaRb_Internal = rb_define_class_under(rb_mCppjiebaRb, "Internal", rb_cData);
+    rb_cCppjiebaRb_Internal = rb_define_class_under(rb_mCppjiebaRb, "Internal", rb_cObject);
     rb_define_alloc_func(rb_cCppjiebaRb_Internal, internal_alloc);
     rb_define_method(rb_cCppjiebaRb_Internal, "initialize", (ruby_method*) &internal_initialize, 5);
     rb_define_method(rb_cCppjiebaRb_Internal, "extract_keyword", (ruby_method*) &internal_extract_keyword, 2);


### PR DESCRIPTION
rb_cData was deprecated in Ruby 3.1 and removed in Ruby 3.2.

- https://github.com/ruby/ruby/commit/089b7a8
- https://bugs.ruby-lang.org/issues/3072#note-15

Fixes #3 

Without this change, compiling results in this error:

```
compiling ../../../../ext/cppjieba_rb/internal.cc
../../../../ext/cppjieba_rb/internal.cc: In function ‘void Init_internal()’:
../../../../ext/cppjieba_rb/internal.cc:166:81: error: ‘rb_cData’ was not declared in this scope; did you mean ‘rb_eFatal’?
  166 |     rb_cCppjiebaRb_Internal = rb_define_class_under(rb_mCppjiebaRb, "Internal", rb_cData);
      |                                                                                 ^~~~~~~~
      |                                                                                 rb_eFatal
make: *** [Makefile:214: internal.o] Error 1
```